### PR TITLE
Minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ yalc*
 
 # output
 dist/
+
+yarn.lock

--- a/plugin.json
+++ b/plugin.json
@@ -21,7 +21,7 @@
         {
             "key": "eventMethodType",
             "name": "The type of method for the event url",
-            "default": "post",
+            "default": "POST",
             "type": "string"
         },
         {


### PR DESCRIPTION
## Changes

Hey! Thank you so much for this! It's super cool!

I've made a few changes to incorporate some best practices. Feel free to push back / ask more about it.

### processEventBatch

We're deprecating this with the new release that's coming out today, so I moved this plugin to a new approach using `onEvent`. `onEvent` is used for plugins that need to read the event but don't modify it, as is the case here. Docs for this are coming out today.

### statusOk

The current checking mechanism would only match a 200, in which case it could just check if the status is equal to 200. To check for all 2xx codes, I've added in `statusOk`. Other plugins use this as well.

## Suggestions

I haven't tried this out myself but I'm happy to get it in and iterate from there. A few things I'd suggest, but that are not necessary at this stage:

### Additional config verification

I'd check `config.eventMethodType` for example. In fact, a better choice might be to use the `choice` type with options like 'POST' and 'PUT', or whatever should be allowed. You could also check for leading slashes on the event path etc. Essentially anything that would cause an error to be thrown during `onEvent` rather than `setupPlugin`.

### Tests

These are always nice :D

### Retry queue for failed requests

This is something that recent developments in the plugin server allow for. I'm supposed to implement a few plugins using retry queues this cycle so you could use those as an example to implement it here too. You couldn't have known this was possible yet though because the docs are also coming later today.


## Questions

Do you not want to send event names to Salesforce? 
