### PR TITLE
Add buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
+        "@posthog/plugin-contrib": "^0.0.3"
     }
 }


### PR DESCRIPTION
## Changes

This is completely untested code that I just wrote in 2min. It's important to add this buffer so that this plugin doesn't stall our event ingestion waiting for a response from Salesforce. This ensures it will run in the background.

Retry queues should come next, but this is more essential at this point.

## Checklist

-   [ ] Tests for new code
