### PR TITLE
chore: properties field comes encoded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ async function sendEventToSalesforce(event: PluginEvent, meta: SalesforcePluginM
         const response = await fetch(`${config.salesforceHost}/${config.eventPath}`, {
             method: config.eventMethodType,
             headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-            body: JSON.stringify(event.properties),
+            body: event.properties,
         })
 
         const isOk = await statusOk(response, global.logger)


### PR DESCRIPTION
looks like the properties is already encoded now due to some posthog sales. so just send the string of the data already

## Changes

...

## Checklist

-   [ ] Tests for new code
