### PR TITLE
Update properties logic

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -58,6 +58,12 @@
             "hint": "Comma separated list of events to include"
         },
         {
+            "key": "parametersToInclude",
+            "name": "Parameters to include",
+            "type": "string",
+            "hint": "Comma separated list of parameters to include"
+        },
+        {
             "key": "debugLogging",
             "name": "Enable debug logging",
             "type": "choice",


### PR DESCRIPTION
## Changes

- Now checking if the event is in the `eventsToInclude` list before adding it to the buffer.
- A new property `parametersToInclude`. 

## Explanation

### Events to include

We have a high volume of events, and the ones we want to send to Salesforce are not that common. If we were to check if the events are in the `eventsToInclude` list only in the `sendEventToSalesforce`, most of the buffer would go to waste. 

This isn't broken now, but I assume it'll be easier to debug if the plug-in breaks.

### Parameters to include

Salesforce is strict with the parameters we send in the `/services/data/v55.0/sobjects/Lead` endpoint -- only accepting those that match existing columns in the Lead object (same for any sort of object).

We have a few parameters in our events (`$ip`, `distinct_id` etc) that would break the integration, hence the `parametersToInclude` config – only sending the parameters we want.

## Final notes

I haven't tested these changes as there's no way to run custom plugins in PostHog Cloud.
